### PR TITLE
Fix pack/lock version numbers for v2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ninetails",
-  "version": "2.0.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ninetails",
-      "version": "2.0.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "electron-squirrel-startup": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ninetails",
   "productName": "Ninetails",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A private, fast, and beautiful web browser.",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
Unnoticed since v2.0.0